### PR TITLE
Various updates

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -1,0 +1,31 @@
+# This workflows will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*

--- a/README.md
+++ b/README.md
@@ -90,15 +90,14 @@ Applying Cogbooks will again result in:
 # STUDENT CODE HERE
 ```
 
-To leave a "stubbed" assignment expression, one can use `<COGSTUB>`:
+To leave a "stubbed" assignment expression, one can use `<COGSTUB>` to the right of an assignment (i.e. an expression using `=`):
 
 ````
 ```python
-# set-up code here
 x = 33.1 # <COGSTUB>  compute `x`
 ```
 ````
-Applying Cogbooks will again result in:
+Applying Cogbooks will leave behind a "stub" for that assignment:
 
 ```python
 x = # compute `x`

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ By default, existing notebooks will not be overwritten. Specifying `--force` or 
 
 
 ## Forms of Delimiters
-Any instructor-only markdown file should be properly delimited. To delimit blocks of Python code, use:
+Any instructor-only markdown file should be properly delimited. To delimit blocks of Python code, use `<COGINST>`:
 ````
 ```python
 # set-up code here
@@ -77,7 +77,7 @@ Running Cogbooks will then yield:
 # STUDENT CODE HERE
 ```
 
-Alternatively, to remove single lines of code, use:
+Alternatively, to remove single lines of code, use `<COGLINE>`:
 ````
 ```python
 # set-up code here
@@ -88,6 +88,20 @@ Applying Cogbooks will again result in:
 ```python
 # set-up code here
 # STUDENT CODE HERE
+```
+
+To leave a "stubbed" assignment expression, one can use `<COGSTUB>`:
+
+````
+```python
+# set-up code here
+x = 33.1 # <COGSTUB>  compute `x`
+```
+````
+Applying Cogbooks will again result in:
+
+```python
+x = # compute `x`
 ```
 
 

--- a/src/cogbooks/_functions.py
+++ b/src/cogbooks/_functions.py
@@ -5,6 +5,9 @@ from pathlib import Path
 
 from jupytext.cli import jupytext
 
+JUPYTEXT_HEADER = """---
+jupyter:
+  jupytext:"""
 
 def strip_text(text: str) -> str:
     """
@@ -62,7 +65,14 @@ def make_student_files(path: Path, outdir: Path, force: bool) -> bool:
 
     if path.is_file() and path.suffix == ".md" and path.stem != "README":
         with path.open(mode="r") as f:
-            student_notebook_text = strip_text(f.read())
+            file_contents = f.read()
+        
+        if not file_contents.startswith(JUPYTEXT_HEADER):
+            print(path.name + " is not a jupytext-formatted markdown file")
+            return False
+
+        student_notebook_text = strip_text(file_contents)
+        del file_contents
 
         student_markdown_path = outdir / (path.stem + "_STUDENT.md")
         student_notebook_path = student_markdown_path.parent / (

--- a/src/cogbooks/_functions.py
+++ b/src/cogbooks/_functions.py
@@ -40,7 +40,15 @@ def strip_text(text: str) -> str:
 
     # Remove single lines from code (with `<COGLINE>` addendum), preserving whitespace
     # and replace with a STUDENT CODE HERE comment
-    return re.sub(r"\S(?<!\s)(.*?)<COGLINE>", "# STUDENT CODE HERE", stu_notebook)
+    stu_notebook = re.sub(r"\S(?<!\s)(.*?)<COGLINE>", "# STUDENT CODE HERE", stu_notebook)
+
+    # Replace expression to the right of a `=` and left of `<COGSTUB>` with a comment.
+    # z = 1 # <COGSTUB> compute `z`
+    # z = # compute `z`
+    stu_notebook = re.sub(r"=.\S(?<!\s)(.*?)<COGSTUB>", "= #", stu_notebook)
+
+    return stu_notebook
+
 
 
 def make_student_files(path: Path, outdir: Path, force: bool) -> bool:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,7 @@ def cleandir() -> str:
         os.mkdir('test_files')
         dest = Path.cwd() / 'test_files'
         shutil.copy(data_dir / 'test.md', dest)
+        shutil.copy(data_dir / 'not_jupytext.md', dest)
         shutil.copy(data_dir / 'test_STUDENT.ipynb', dest)
         yield tmpdirname
         os.chdir(old_dir)

--- a/tests/test_file_handling.py
+++ b/tests/test_file_handling.py
@@ -13,6 +13,7 @@ def test_dir_ipynb_doesnt_exist():
     assert not dest.exists()
     os.system(f"cogbooks test_files")
     assert dest.exists()
+    assert len(list((Path(".") / "test_files").glob("*.ipynb"))) == 1
 
 
 @pytest.mark.usefixtures("cleandir")

--- a/tests/test_files/not_jupytext.md
+++ b/tests/test_files/not_jupytext.md
@@ -1,0 +1,1 @@
+Should not be parsed by Cogbooks


### PR DESCRIPTION
- Adds `<COGSTUB>` feature
- `make_student_files` skips markdown files that don't start with jupytext header
- Add GitHub action for publishing to pypi (publishing a newly-tagged release of `cogbooks` will result in the new version being published to pypi)
- Improve test robustness


Seeing **`<COGSTUB>`** in action:

**Before**:

Previously,  we would could detail a solution as

```python
# create a list containing 0, 2, 4, 8 and assign it to `x`
x = list(range(0, 10, 2)) # <COGLINE>
```

the students would then see:

```python
# create a list containing 0, 2, 4, 8 and assign it to `x`
# STUDENT CODE HERE
```

**After**:


This is what a solution using `<COGSTUB> looks like:

```python
x = list(range(0, 10, 2)) # <COGSTUB> create a list containing 0, 2, 4, 8
```

Applying cogbooks, this is what the students will see:

```python
x = # create a list containing 0, 2, 4, 8
```

this might not seem like a big difference, but it provides students with more structure, and less of an intimidating blank canvas to work with.